### PR TITLE
Upstream changes by Diablo Team, Tsinghua University

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ OPTFLAGS = -O3 -xHost -qopenmp -DPRINT_DIST_STATS #-DPRINT_EXTRA_NEDGES #-DUSE_M
 #-DUSE_MPI_SENDRECV
 #-DUSE_MPI_COLLECTIVES
 # use export ASAN_OPTIONS=verbosity=1 to check ASAN output
-SNTFLAGS = -std=c++11 -fopenmp -fsanitize=address -O1 -fno-omit-frame-pointer
-CXXFLAGS = -std=c++11 -g $(OPTFLAGS)
+SNTFLAGS = -std=c++17 -fopenmp -fsanitize=address -O1 -fno-omit-frame-pointer
+CXXFLAGS = -std=c++17 -g $(OPTFLAGS)
 
 OBJ = main.o
 TARGET = miniVite

--- a/dspl.hpp
+++ b/dspl.hpp
@@ -191,30 +191,30 @@ GraphElem distGetMaxIndex(const std::unordered_map<GraphElem, GraphWeight> &clma
   assert(!clmap.empty());
 #endif
   for (auto [tcomm, tweight] : clmap) {
-      if (currComm != tcomm) {
+      // currComm != tcomm is always true
+      // because this case is handled in distBuildLocalMapCounter
 
-          // is_local, direct access local info
-          if ((tcomm >= base) && (tcomm < bound)) {
-              ay = localCinfo[tcomm - base].degree;
-              size = localCinfo[tcomm - base].size;
-          }
-          else {
-              // is_remote, lookup map
-              std::map<GraphElem,Comm>::const_iterator citer = remoteCinfo.find(tcomm);
-              ay = citer->second.degree;
-              size = citer->second.size; 
-          }
+      // is_local, direct access local info
+      if ((tcomm >= base) && (tcomm < bound)) {
+          ay = localCinfo[tcomm - base].degree;
+          size = localCinfo[tcomm - base].size;
+      }
+      else {
+          // is_remote, lookup map
+          std::map<GraphElem,Comm>::const_iterator citer = remoteCinfo.find(tcomm);
+          ay = citer->second.degree;
+          size = citer->second.size; 
+      }
 
-          eiy = tweight;
+      eiy = tweight;
 
-          curGain = 2.0 * (eiy - eix) - 2.0 * vDegree * (ay - ax) * constant;
+      curGain = 2.0 * (eiy - eix) - 2.0 * vDegree * (ay - ax) * constant;
 
-          if ((curGain > maxGain) ||
-                  ((curGain == maxGain) && (curGain != 0.0) && (tcomm < maxIndex))) {
-              maxGain = curGain;
-              maxIndex = tcomm;
-              maxSize = size;
-          }
+      if ((curGain > maxGain) ||
+              ((curGain == maxGain) && (curGain != 0.0) && (tcomm < maxIndex))) {
+          maxGain = curGain;
+          maxIndex = tcomm;
+          maxSize = size;
       }
   }
 


### PR DESCRIPTION
Submit our optimizations done in SC20 VSCC at @thu-scc. I split our original changes at https://github.com/thu-scc/SC20-miniVite/commit/b9846fc1cfa750e15c6b0f9b1fe153b94dca5b80 into small commits. The main changes are:

1. Merge `clmap` and `counter` into a `map<GraphElem, GraphWeight>`
2. Replace `unordered_map` with fixed-size and dynamic size arrays when the `e1 - e0` is below threshold.
