### PR TITLE
Bugfix: Metall CXX17 filesystem link error with Clang

### DIFF
--- a/cmake/include_cxx_filesystem_library.cmake
+++ b/cmake/include_cxx_filesystem_library.cmake
@@ -2,35 +2,37 @@
 # If it is not available, uses own implementation.
 function(include_cxx_filesystem_library)
 
+    set(FOUND_CXX17_FILESYSTEM_LIB TRUE PARENT_SCOPE)
+    set(REQUIRE_LIB_STDCXX_FS FALSE PARENT_SCOPE)
+
     # Check if C++17 <filesystem> header files are available
     # If not, uses our own implementation.
     include(CheckIncludeFileCXX)
-    CHECK_INCLUDE_FILE_CXX(filesystem FILESYSTEM_INCLUDE_FILE)
-    if (NOT FILESYSTEM_INCLUDE_FILE)
-        message(STATUS "Cannot find the C++17 <filesystem> library. Use own implementation.")
-        add_definitions(-DMETALL_NOT_USE_CXX17_FILESYSTEM_LIB)
+    CHECK_INCLUDE_FILE_CXX(filesystem FOUND_FILESYSTEM_HEADER)
+    if (NOT FOUND_FILESYSTEM_HEADER)
+        message(STATUS "Cannot find the C++17 <filesystem> library.")
+        set(FOUND_CXX17_FILESYSTEM_LIB FALSE PARENT_SCOPE)
         return()
     endif ()
 
     # Find the correct option to link the C++17 <filesystem> library
-    # GCC: stdc++fs
-    # Clang + macOS >= 10.15: c++fs
-    # Clang + macOS < 10.15: uses our own implementation
-    # Clang + the other OS: c++fs
+    # GCC
+    #   Any platform: stdc++fs
+    # LLVM
+    #   Assumes LLVM >= 9.0 and libc++ >= 7.0.
+    #   Clang + macOS >= 10.15: nothing special is required to use <filesystem>
+    #   Clang + macOS < 10.15: uses our own implementation
+    #   Clang + the other OS: nothing special is required to use <filesystem>
     if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")) # GCC
-        link_libraries(stdc++fs)
+        set(REQUIRE_LIB_STDCXX_FS TRUE PARENT_SCOPE)
     elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")  # Clang or AppleClang
-        if (NOT APPLE) # Not macOS
-            link_libraries(c++fs)
-        else()
+        if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin") # macOS
             include(get_macos_version)
-            get_macos_version() # Get MacOS version
+            get_macos_version() # Get macOS version
             message(VERBOSE "macOS version ${MACOS_VERSION}")
-            if (MACOS_VERSION VERSION_GREATER_EQUAL 10.15) # macOS >= 10.15
-                link_libraries(c++fs)
-            else () # macOS < 10.15
-                message(STATUS "macOS >= 10.15 is required to use the C++17 <filesystem> library. Use own implementation.")
-                add_definitions(-DMETALL_NOT_USE_CXX17_FILESYSTEM_LIB)
+            if (MACOS_VERSION VERSION_LESS 10.15) # macOS < 10.15
+                message(STATUS "macOS >= 10.15 is required to use the C++17 <filesystem> library.")
+                set(FOUND_CXX17_FILESYSTEM_LIB FALSE PARENT_SCOPE)
             endif ()
         endif ()
     endif ()


### PR DESCRIPTION
This PR fixes a CXX17 filesystem library link error that happens when Clang compiler is used.
Our new ECP testbed machine uses Clang by default, this PR enables this project to work on the system.

@sg0 
Please let me know if you have any questions.